### PR TITLE
Updating rxjs to 6.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/srijs/rxjs-async-map"
   },
   "dependencies": {
-    "rxjs": "^5.5.6"
+    "rxjs": "^6.3.3"
   },
   "devDependencies": {
     "@types/jest": "^22.1.1",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,20 +1,20 @@
-import { Observable } from 'rxjs';
-
+import { Observable, of, empty } from 'rxjs';
+import {toArray,delay} from 'rxjs/operators';
 import { asyncMap } from './index';
 
 describe('asyncMap', () => {
   it('returns empty observable for empty input', async () => {
     const project = jest.fn();
-    const input = Observable.empty();
-    const output = await input.pipe(asyncMap(project, 0)).toArray().toPromise();
+    const input = empty();
+    const output = await input.pipe(asyncMap(project, 0)).pipe(toArray()).toPromise();
 
     expect(output).toEqual([]);
   });
 
   it('calls project function in-order for all values in input', async () => {
     const project = jest.fn(x => Promise.resolve(x.length));
-    const input = Observable.of('f', 'ba', 'baz');
-    const output = await input.pipe(asyncMap(project, 1)).toArray().toPromise();
+    const input = of('f', 'ba', 'baz');
+    const output = await input.pipe(asyncMap(project, 1)).pipe(toArray()).toPromise();
 
     expect(output).toEqual([1, 2, 3]);
     expect(project.mock.calls).toEqual([['f'], ['ba'], ['baz']]);
@@ -22,13 +22,13 @@ describe('asyncMap', () => {
 
   it('calls project function with the given concurrency', async () => {
     const invocations: {[v: string]: number} = {};
-    const input = Observable.of('foo', 'bar', 'baz');
+    const input = of('foo', 'bar', 'baz');
     const project = jest.fn(v => {
       invocations[v] = Date.now();
 
-      return Observable.of().delay(10).toPromise();
+      return of().pipe(delay(10)).toPromise();
     });
-    await input.pipe(asyncMap(project, 2)).toArray().toPromise();
+    await input.pipe(asyncMap(project, 2)).pipe(toArray()).toPromise();
 
     expect(invocations['bar'] - invocations['foo']).toBeLessThan(5);
     expect(invocations['baz']).toBeGreaterThan(invocations['foo']);
@@ -38,13 +38,13 @@ describe('asyncMap', () => {
   it('returns projected values in-order even if promises resolve out of order', async () => {
     const project = jest.fn(x => {
       if (x === 'foo') {
-        return Observable.of(1).delay(20).toPromise();
+        return of(1).pipe(delay(20)).toPromise();
       } else {
-        return Observable.of(2).delay(10).toPromise();
+        return of(2).pipe(delay(10)).toPromise();
       }
     });
-    const input = Observable.of('foo', 'bar');
-    const output = await input.pipe(asyncMap(project, 1)).toArray().toPromise();
+    const input = of('foo', 'bar');
+    const output = await input.pipe(asyncMap(project, 1)).pipe(toArray()).toPromise();
 
     expect(output).toEqual([1, 2]);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { Observable } from 'rxjs/Observable';
-import { mergeMap } from 'rxjs/operators/mergeMap';
+import { Observable } from 'rxjs';
+import { mergeMap } from 'rxjs/operators';
 
 import { Notifier, notify } from './notify';
 
@@ -20,8 +20,6 @@ const mapper = <T, U>(project: (value: T) => PromiseLike<U>) => {
     notifiers.push(notify(project(value), sub, onReady));
   });
 };
-
-export { Observable };
 
 export const asyncMap = <T, U>(
   project: (item: T) => PromiseLike<U>,

--- a/src/notify.spec.ts
+++ b/src/notify.spec.ts
@@ -1,8 +1,13 @@
-import { Observable } from 'rxjs/Observable';
-import { empty as emptyObserver } from 'rxjs/Observer';
+import { Observable, Observer } from 'rxjs';
 import { expectToReject } from 'jasmine-promise-tools';
-
 import { notify } from './notify';
+
+const emptyObserver : Observer<any> = {
+  closed:true,
+  next(value: any): void { /* noop */},
+  error(err: any): void { throw err; },
+  complete(): void { /*noop*/ }
+}
 
 describe('Notify', () => {
   it('calls onReady when wrapped promise resolves', async () => {

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,4 +1,4 @@
-import { Observer } from 'rxjs/Observer';
+import { Observer } from 'rxjs';
 
 export interface Notifier {
   notifyIfReady(): boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,9 @@
       "dom",
       "es5",
       "es2015.core",
-      "es2015.promise"
+      "es2015.promise",
+      "es2015.iterable",
+      "es2015.symbol"
     ]
   },
   "include": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,11 +2767,11 @@ rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-rxjs@^5.5.6:
-  version "5.5.10"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.10.tgz#fde02d7a614f6c8683d0d1957827f492e09db045"
+rxjs@^6.3.3:
+  version "6.3.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
   dependencies:
-    symbol-observable "1.0.1"
+    tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -3086,10 +3086,6 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
 symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
@@ -3192,6 +3188,10 @@ ts-jest@^22.0.3:
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.0.tgz#e37a86fda8cbbaf23a057f473c9f4dc64e5fc2e8"
+
+tslib@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
 
 tslint@^5.9.1:
   version "5.9.1"


### PR DESCRIPTION
- Upgraded rxjs dependency
- fixed tsconfig (added missing libs)
- converted to new pipe syntax
- Fixed errors in tests